### PR TITLE
fix: add package name prefix

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -27,7 +27,7 @@ const project = new CdklabsConstructLibrary({
   jsiiTargetLanguages: [JsiiLanguage.PYTHON],
 
   publishToPypi: {
-    distName: 'cdk-pipelines-github',
+    distName: 'hojulian.cdk-pipelines-github',
     module: 'hojulian.cdk_pipelines_github',
   },
 });

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "outdir": "dist",
     "targets": {
       "python": {
-        "distName": "cdk-pipelines-github",
+        "distName": "hojulian.cdk-pipelines-github",
         "module": "hojulian.cdk_pipelines_github"
       }
     },


### PR DESCRIPTION
Addresses build failure: https://github.com/hojulian/cdk-pipelines-github/actions/runs/6953177386/job/18917960683

Changes:

1. Update package config to have a name prefix