### PR TITLE
feat: S3 assembly artifact steps

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -20,6 +20,10 @@
       "type": "build"
     },
     {
+      "name": "@types/uuid",
+      "type": "build"
+    },
+    {
       "name": "@typescript-eslint/eslint-plugin",
       "version": "^6",
       "type": "build"
@@ -109,6 +113,10 @@
     },
     {
       "name": "fast-json-patch",
+      "type": "bundled"
+    },
+    {
+      "name": "uuid",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -321,13 +321,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=prod,peer --filter=decamelize,fast-json-patch,yaml,aws-cdk-lib,constructs"
+          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=prod,peer --filter=decamelize,fast-json-patch,uuid,yaml,aws-cdk-lib,constructs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade decamelize fast-json-patch yaml aws-cdk-lib constructs"
+          "exec": "yarn upgrade decamelize fast-json-patch uuid yaml aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"
@@ -369,13 +369,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=dev --filter=@aws-cdk/integ-runner,@aws-cdk/integ-tests-alpha,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,aws-cdk-lib,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@latest --upgrade --target=minor --peer --dep=dev --filter=@aws-cdk/integ-runner,@aws-cdk/integ-tests-alpha,@types/jest,@types/node,@types/uuid,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,aws-cdk-lib,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest ts-node typescript"
+          "exec": "yarn upgrade @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @types/jest @types/node @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib cdklabs-projen-project-types eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest ts-node typescript"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,12 +13,13 @@ const project = new CdklabsConstructLibrary({
   constructsVersion: '10.0.46',
   defaultReleaseBranch: 'main',
   repositoryUrl: 'https://github.com/hojulian/cdk-pipelines-github.git',
-  bundledDeps: ['decamelize', 'yaml', 'fast-json-patch'],
+  bundledDeps: ['decamelize', 'yaml', 'fast-json-patch', 'uuid'],
   devDeps: [
     'cdklabs-projen-project-types',
     'aws-cdk-lib',
     '@aws-cdk/integ-runner@^2.60.0',
     '@aws-cdk/integ-tests-alpha',
+    '@types/uuid',
   ],
   peerDeps: ['aws-cdk-lib'],
   jestOptions: {

--- a/API.md
+++ b/API.md
@@ -5420,6 +5420,8 @@ public readonly jobSteps: JobStep[];
 
 ### GithubAssemblyArtifactOptions <a name="GithubAssemblyArtifactOptions" id="@hojulian/cdk-pipelines-github.GithubAssemblyArtifactOptions"></a>
 
+Github assembly artifact options uses built-in `upload-artifact/download-artifact` for artifacts handling.
+
 #### Initializers <a name="Initializers" id="@hojulian/cdk-pipelines-github.GithubAssemblyArtifactOptions.Initializer"></a>
 
 ```typescript
@@ -6016,6 +6018,82 @@ public readonly WINDOWS_LATEST: Runner;
 Runner instance that sets runsOn to `windows-latest`.
 
 ---
+
+### S3AssemblyArtifactOptions <a name="S3AssemblyArtifactOptions" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions"></a>
+
+S3 assembly artifact options uses a given S3 bucket for artifacts handling.
+
+#### Initializers <a name="Initializers" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.Initializer"></a>
+
+```typescript
+import { S3AssemblyArtifactOptions } from '@hojulian/cdk-pipelines-github'
+
+new S3AssemblyArtifactOptions(bucket: string)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.Initializer.parameter.bucket">bucket</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `bucket`<sup>Required</sup> <a name="bucket" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.Initializer.parameter.bucket"></a>
+
+- *Type:* string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.downloadAssemblySteps">downloadAssemblySteps</a></code> | Configure download assembly steps. |
+| <code><a href="#@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.uploadAssemblySteps">uploadAssemblySteps</a></code> | Configure upload assembly steps. |
+
+---
+
+##### `downloadAssemblySteps` <a name="downloadAssemblySteps" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.downloadAssemblySteps"></a>
+
+```typescript
+public downloadAssemblySteps(targetName: string, targetDir: string): JobStep[]
+```
+
+Configure download assembly steps.
+
+###### `targetName`<sup>Required</sup> <a name="targetName" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.downloadAssemblySteps.parameter.targetName"></a>
+
+- *Type:* string
+
+---
+
+###### `targetDir`<sup>Required</sup> <a name="targetDir" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.downloadAssemblySteps.parameter.targetDir"></a>
+
+- *Type:* string
+
+---
+
+##### `uploadAssemblySteps` <a name="uploadAssemblySteps" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.uploadAssemblySteps"></a>
+
+```typescript
+public uploadAssemblySteps(sourceName: string, sourceDir: string): JobStep[]
+```
+
+Configure upload assembly steps.
+
+###### `sourceName`<sup>Required</sup> <a name="sourceName" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.uploadAssemblySteps.parameter.sourceName"></a>
+
+- *Type:* string
+
+---
+
+###### `sourceDir`<sup>Required</sup> <a name="sourceDir" id="@hojulian/cdk-pipelines-github.S3AssemblyArtifactOptions.uploadAssemblySteps.parameter.sourceDir"></a>
+
+- *Type:* string
+
+---
+
+
+
 
 ### YamlFile <a name="YamlFile" id="@hojulian/cdk-pipelines-github.YamlFile"></a>
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@aws-cdk/integ-tests-alpha": "latest",
     "@types/jest": "^27",
     "@types/node": "^16",
+    "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "aws-cdk-lib": "2.9.0",
@@ -74,11 +75,13 @@
   "dependencies": {
     "decamelize": "^5.0.1",
     "fast-json-patch": "^3.1.1",
+    "uuid": "^9.0.1",
     "yaml": "^2.3.4"
   },
   "bundledDependencies": [
     "decamelize",
     "fast-json-patch",
+    "uuid",
     "yaml"
   ],
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/uuid@^9.0.7":
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.7.tgz#b14cebc75455eeeb160d5fe23c2fcc0c64f724d8"
+  integrity sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -5235,6 +5240,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
New `S3AssemblyArtifactOptions` allows the user to use S3 for upload/download artifacts.

for example:

```ts
new S3AssemblyArtifactOptions("test-bucket-us-east-2");
```