### PR TITLE
fix: add missing slash to s3 assembly step

### DIFF
--- a/src/pipeline-options.ts
+++ b/src/pipeline-options.ts
@@ -71,14 +71,14 @@ export class S3AssemblyArtifactOptions extends AssemblyArtifactOptions {
   downloadAssemblySteps(targetName: string, targetDir: string): github.JobStep[] {
     return [{
       name: `Download ${targetName} from S3`,
-      run: `aws s3 sync \ \ns3://${this.bucket}/${this.seed}/${targetName}\ \n${targetDir}`,
+      run: ['aws s3 sync', `s3://${this.bucket}/${this.seed}/${targetName}`, targetDir].join(' \\ \n'),
     }];
   }
 
   uploadAssemblySteps(sourceName: string, sourceDir: string): github.JobStep[] {
     return [{
       name: `Upload ${sourceName} to S3`,
-      run: `aws s3 sync \ \n${sourceDir} \ \ns3://${this.bucket}/${this.seed}/${sourceName}`,
+      run: ['aws s3 sync', sourceDir, `s3://${this.bucket}/${this.seed}/${sourceName}`].join(' \\ \n'),
     }];
   }
 }


### PR DESCRIPTION
Fixes missing backslash in the S3 assembly command.

Before:

```bash
aws s3 sync
cdk.out
s3://some-bucket/a612cee5-fa6c-472c-a560-2ff724bf1af8/cdk.out
```

After:

```bash
aws s3 sync  \
cdk.out  \
s3://some-bucket/a612cee5-fa6c-472c-a560-2ff724bf1af8/cdk.out
```